### PR TITLE
Fix wrong folder sync

### DIFF
--- a/lib/gzr/commands/dashboard/import.rb
+++ b/lib/gzr/commands/dashboard/import.rb
@@ -83,8 +83,8 @@ module Gzr
                 end
               end
               upsert_plans_for_dashboard(dashboard.id,@me.id,data[:scheduled_plans]) if data[:scheduled_plans]
-              output.puts "Imported dashboard #{dashboard.id}" unless @options[:plain] 
-              output.puts dashboard.id if @options[:plain] 
+              output.puts "Imported dashboard #{dashboard.id}" unless @options[:plain]
+              output.puts dashboard.id if @options[:plain]
             end
           end
         end
@@ -170,7 +170,7 @@ module Gzr
             element = new_element.select do |k,v|
               (keys_to_keep('create_dashboard_element') - [:dashboard_id, :look_id, :query_id, :merge_result_id]).include? k
             end
-            (element[:query_id],element[:look_id],element[:merge_result_id]) = process_dashboard_element(new_element) 
+            (element[:query_id],element[:look_id],element[:merge_result_id]) = process_dashboard_element(new_element)
             say_warning "Creating dashboard element #{element.inspect}" if @options[:debug]
             element[:dashboard_id] = dashboard_id
             result_maker = copy_result_maker_filterables(new_element)
@@ -188,7 +188,7 @@ module Gzr
               (keys_to_keep('update_dashboard_element') - [:dashboard_id, :look_id, :query_id, :merge_result_id]).include? k
             end
             )
-            (element[:query_id],element[:look_id],element[:merge_result_id]) = process_dashboard_element(new_element) 
+            (element[:query_id],element[:look_id],element[:merge_result_id]) = process_dashboard_element(new_element)
             say_warning "Updating dashboard element #{existing_element.id}" if @options[:debug]
             result_maker = copy_result_maker_filterables(new_element)
             element[:result_maker] = result_maker if result_maker

--- a/lib/gzr/commands/dashboard/import.rb
+++ b/lib/gzr/commands/dashboard/import.rb
@@ -113,7 +113,7 @@ module Gzr
             if @options[:force] then
               say_ok "Modifying existing dashboard #{existing_dashboard.id} #{existing_dashboard[:title]} in space #{target_space_id}"
               new_dash = source.select do |k,v|
-                (keys_to_keep('update_dashboard') - [:space_id,:user_id,:slug]).include? k
+                (keys_to_keep('update_dashboard') - [:folder_id,:space_id,:user_id,:slug]).include? k
               end
               new_dash[:slug] = source[:slug] unless slug_used
               return update_dashboard(existing_dashboard.id,new_dash)
@@ -122,7 +122,7 @@ module Gzr
             end
           else
             new_dash = source.select do |k,v|
-              (keys_to_keep('create_dashboard') - [:space_id,:user_id,:slug]).include? k
+              (keys_to_keep('create_dashboard') - [:folder_id,:space_id,:user_id,:slug]).include? k
             end
             new_dash[:slug] = source[:slug] unless slug_used
             new_dash[:space_id] = target_space_id

--- a/lib/gzr/modules/look.rb
+++ b/lib/gzr/modules/look.rb
@@ -39,7 +39,7 @@ module Gzr
       data = nil
       begin
         req = { :slug => slug }
-        req[:space_id] = space_id if space_id 
+        req[:space_id] = space_id if space_id
         data = @sdk.search_looks(req)
       rescue LookerSDK::Error => e
         say_error "Error search_looks_by_slug(#{JSON.pretty_generate(req)})"
@@ -53,7 +53,7 @@ module Gzr
       data = nil
       begin
         req = { :title => title }
-        req[:space_id] = space_id if space_id 
+        req[:space_id] = space_id if space_id
         data = @sdk.search_looks(req)
       rescue LookerSDK::Error => e
         say_error "Error search_looks_by_title(#{JSON.pretty_generate(req)})"
@@ -141,14 +141,14 @@ module Gzr
     def create_fetch_query(source_query)
       new_query = source_query.select do |k,v|
         (keys_to_keep('create_query') - [:client_id]).include? k
-      end 
+      end
       return create_query(new_query)
     end
 
     def create_merge_result(merge_result)
       new_merge_result = merge_result.select do |k,v|
         (keys_to_keep('create_merge_query') - [:client_id,:source_queries]).include? k
-      end 
+      end
       new_merge_result[:source_queries] = merge_result[:source_queries].map do |query|
         new_query = {}
         new_query[:query_id] = create_fetch_query(query[:query]).id

--- a/lib/gzr/modules/look.rb
+++ b/lib/gzr/modules/look.rb
@@ -117,7 +117,7 @@ module Gzr
         if @options[:force] then
           say_ok "Modifying existing Look #{source_look[:title]} in space #{space_id}"
           new_look = source_look.select do |k,v|
-            (keys_to_keep('update_look') - [:space_id,:user_id,:query_id,:slug]).include? k
+            (keys_to_keep('update_look') - [:folder_id,:space_id,:user_id,:query_id,:slug]).include? k
           end
           new_look[:slug] = source_look[:slug] unless slug_used
           new_look[:query_id] = query_id
@@ -127,7 +127,7 @@ module Gzr
         end
       else
         new_look = source_look.select do |k,v|
-          (keys_to_keep('create_look') - [:space_id,:user_id,:query_id,:slug]).include? k
+          (keys_to_keep('create_look') - [:folder_id,:space_id,:user_id,:query_id,:slug]).include? k
         end
         new_look[:slug] = source_look[:slug] unless slug_used
         new_look[:query_id] = query_id


### PR DESCRIPTION
folder_id and space_id are the same in the source, and if folder_id is
kept, Looker may use that instead of the space_id which we specify.

This behavior seems to have changed with the deploy of Looker 6.22.